### PR TITLE
Updated horned owl dependency to latest stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.15.1"
 features = ["abi3-py37", "extension-module"]
 
 [dependencies]
-horned-owl = { git = "https://github.com/phillord/horned-owl", version = "0.12.1-alpha.0", branch="devel"}
+horned-owl = { git = "https://github.com/phillord/horned-owl", version = "0.14.0", tag = "v0.14.0"}
 curie = "0.1.1"
 failure = "0.1.2"
 


### PR DESCRIPTION
I tried to build the binaries with github and I got an error. Now they build using this config but I think it would be reasonable to test it out a bit. I will try running the notebook locally and see if it is being consistent.