### PR TITLE
Add load and save serialization options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ features = ["abi3-py37", "extension-module", "experimental-inspect"]
 
 [dependencies]
 horned-owl = "1.0.0"
+horned-bin = "1.0.0"
 curie = "0.1.2"
 failure = "0.1.8"
 quote = "1.0"

--- a/pyhornedowl/__init__.py
+++ b/pyhornedowl/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
-from .pyhornedowl import PyIndexedOntology, open_ontology, get_descendants, get_ancestors
+from .pyhornedowl import PyIndexedOntology, open_ontology, open_ontology_from_file, open_ontology_from_string, get_descendants, get_ancestors
 
-__all__ = ["PyIndexedOntology", "open_ontology", "get_descendants", "get_ancestors"]
+__all__ = ["PyIndexedOntology", "open_ontology", "open_ontology_from_file", "open_ontology_from_string", "get_descendants", "get_ancestors"]

--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -97,9 +97,10 @@ class PyIndexedOntology:
         """
         ...
 
-    def save_to_file(self, file_name: str) -> None:
+    def save_to_file(self, file_name: str, format: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> None:
         """
-        Saves the ontology to disk in owx format.
+        Saves the ontology to disk. If no format is given it is guessed by the file extension.
+        Defaults to owx
         """
         ...
 

--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -97,10 +97,10 @@ class PyIndexedOntology:
         """
         ...
 
-    def save_to_file(self, file_name: str, format: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> None:
+    def save_to_file(self, file_name: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> None:
         """
-        Saves the ontology to disk. If no format is given it is guessed by the file extension.
-        Defaults to owx
+        Saves the ontology to disk. If no serialization is given it is guessed by the file extension.
+        Defaults to OWL/XML
         """
         ...
 
@@ -141,8 +141,28 @@ def open_ontology(ontology: str) -> PyIndexedOntology:
     """
     Opens an ontology from a path or plain text.
     
-    If `ontology` is a path, the file is loaded. Otherwise, `ontology` is interepreted as an ontology in either owx or owl format.
-    Note: Only .owl and .owx files are currently supported.
+    If `ontology` is a path, the file is loaded. Otherwise, `ontology` is interpreted as an ontology
+    in plain text.
+    If no serialization is specified the serialization is guessed by the file extension or all parsers are tried
+    until one succeeds.
+    """
+     ...
+
+
+def open_ontology_from_file(path: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology:
+    """
+    Opens an ontology from a file
+    
+    If the serialization is not specified it is guessed from the file extension. Defaults to OWL/XML.
+    """
+     ...
+
+
+def open_ontology_from_string(ontology: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology:
+    """
+    Opens an ontology from plain text.
+    
+    If no serialization is specified, all parsers are tried until one succeeds
     """
      ...
 

--- a/pyhornedowl/model/__init__.py
+++ b/pyhornedowl/model/__init__.py
@@ -1,4 +1,5 @@
 from ..pyhornedowl import model
+import typing
 
 Class = model.Class
 ObjectIntersectionOf = model.ObjectIntersectionOf
@@ -107,25 +108,4 @@ Atom = model.Atom
 IArgument = model.IArgument
 DArgument = model.DArgument
 
-__all__ = ['Class', 'ObjectIntersectionOf', 'ObjectUnionOf', 'ObjectComplementOf', 'ObjectOneOf',
-           'ObjectSomeValuesFrom', 'ObjectAllValuesFrom', 'ObjectHasValue', 'ObjectHasSelf', 'ObjectMinCardinality',
-           'ObjectMaxCardinality', 'ObjectExactCardinality', 'DataSomeValuesFrom', 'DataAllValuesFrom', 'DataHasValue',
-           'DataMinCardinality', 'DataMaxCardinality', 'DataExactCardinality', 'Datatype', 'DataIntersectionOf',
-           'DataUnionOf', 'DataComplementOf', 'DataOneOf', 'DatatypeRestriction', 'SimpleLiteral', 'LanguageLiteral',
-           'DatatypeLiteral', 'ObjectProperty', 'InverseObjectProperty', 'AnnotatedComponent', 'Annotation',
-           'AnnotationAssertion', 'AnnotationProperty', 'AnnotationPropertyDomain', 'AnnotationPropertyRange',
-           'AnonymousIndividual', 'AsymmetricObjectProperty', 'ClassAssertion', 'DataProperty', 'DataPropertyAssertion',
-           'DataPropertyDomain', 'DataPropertyRange', 'DatatypeDefinition', 'DeclareAnnotationProperty', 'DeclareClass',
-           'DeclareDataProperty', 'DeclareDatatype', 'DeclareNamedIndividual', 'DeclareObjectProperty',
-           'DifferentIndividuals', 'DisjointClasses', 'DisjointDataProperties', 'DisjointObjectProperties',
-           'DisjointUnion', 'EquivalentClasses', 'EquivalentDataProperties', 'EquivalentObjectProperties',
-           'FacetRestriction', 'FunctionalDataProperty', 'FunctionalObjectProperty', 'HasKey', 'IRI', 'Import',
-           'InverseFunctionalObjectProperty', 'InverseObjectProperties', 'IrreflexiveObjectProperty', 'NamedIndividual',
-           'NegativeDataPropertyAssertion', 'NegativeObjectPropertyAssertion', 'ObjectPropertyAssertion',
-           'ObjectPropertyDomain', 'ObjectPropertyRange', 'OntologyAnnotation', 'ReflexiveObjectProperty',
-           'SameIndividual', 'SubAnnotationPropertyOf', 'SubClassOf', 'SubDataPropertyOf', 'SubObjectPropertyOf',
-           'SymmetricObjectProperty', 'TransitiveObjectProperty', 'OntologyID', 'DocIRI', 'Rule', 'Variable',
-           'BuiltInAtom', 'ClassAtom', 'DataPropertyAtom', 'DataRangeAtom', 'DifferentIndividualsAtom',
-           'ObjectPropertyAtom', 'SameIndividualAtom', 'Facet', 'ClassExpression', 'ObjectPropertyExpression',
-           'SubObjectPropertyExpression', 'Literal', 'DataRange', 'Individual', 'PropertyExpression',
-           'AnnotationSubject', 'AnnotationValue', 'Component', 'Atom', 'IArgument', 'DArgument']
+__all__ = ['Class', 'ObjectIntersectionOf', 'ObjectUnionOf', 'ObjectComplementOf', 'ObjectOneOf', 'ObjectSomeValuesFrom', 'ObjectAllValuesFrom', 'ObjectHasValue', 'ObjectHasSelf', 'ObjectMinCardinality', 'ObjectMaxCardinality', 'ObjectExactCardinality', 'DataSomeValuesFrom', 'DataAllValuesFrom', 'DataHasValue', 'DataMinCardinality', 'DataMaxCardinality', 'DataExactCardinality', 'Datatype', 'DataIntersectionOf', 'DataUnionOf', 'DataComplementOf', 'DataOneOf', 'DatatypeRestriction', 'SimpleLiteral', 'LanguageLiteral', 'DatatypeLiteral', 'ObjectProperty', 'InverseObjectProperty', 'AnnotatedComponent', 'Annotation', 'AnnotationAssertion', 'AnnotationProperty', 'AnnotationPropertyDomain', 'AnnotationPropertyRange', 'AnonymousIndividual', 'AsymmetricObjectProperty', 'ClassAssertion', 'DataProperty', 'DataPropertyAssertion', 'DataPropertyDomain', 'DataPropertyRange', 'DatatypeDefinition', 'DeclareAnnotationProperty', 'DeclareClass', 'DeclareDataProperty', 'DeclareDatatype', 'DeclareNamedIndividual', 'DeclareObjectProperty', 'DifferentIndividuals', 'DisjointClasses', 'DisjointDataProperties', 'DisjointObjectProperties', 'DisjointUnion', 'EquivalentClasses', 'EquivalentDataProperties', 'EquivalentObjectProperties', 'FacetRestriction', 'FunctionalDataProperty', 'FunctionalObjectProperty', 'HasKey', 'IRI', 'Import', 'InverseFunctionalObjectProperty', 'InverseObjectProperties', 'IrreflexiveObjectProperty', 'NamedIndividual', 'NegativeDataPropertyAssertion', 'NegativeObjectPropertyAssertion', 'ObjectPropertyAssertion', 'ObjectPropertyDomain', 'ObjectPropertyRange', 'OntologyAnnotation', 'ReflexiveObjectProperty', 'SameIndividual', 'SubAnnotationPropertyOf', 'SubClassOf', 'SubDataPropertyOf', 'SubObjectPropertyOf', 'SymmetricObjectProperty', 'TransitiveObjectProperty', 'OntologyID', 'DocIRI', 'Rule', 'Variable', 'BuiltInAtom', 'ClassAtom', 'DataPropertyAtom', 'DataRangeAtom', 'DifferentIndividualsAtom', 'ObjectPropertyAtom', 'SameIndividualAtom', 'Facet', 'ClassExpression', 'ObjectPropertyExpression', 'SubObjectPropertyExpression', 'Literal', 'DataRange', 'Individual', 'PropertyExpression', 'AnnotationSubject', 'AnnotationValue', 'Component', 'Atom', 'IArgument', 'DArgument']

--- a/pyhornedowl/model/__init__.pyi
+++ b/pyhornedowl/model/__init__.pyi
@@ -576,7 +576,6 @@ class ClassAtom:
 class DataPropertyAtom:
     pred: DataProperty
     args: typing.Tuple[DArgument, DArgument]
-
     def __init__(self, pred: DataProperty, args: typing.Tuple[DArgument, DArgument]):
         ...
     ...
@@ -598,7 +597,6 @@ class DifferentIndividualsAtom:
 class ObjectPropertyAtom:
     pred: ObjectPropertyExpression
     args: typing.Tuple[IArgument, IArgument]
-
     def __init__(self, pred: ObjectPropertyExpression, args: typing.Tuple[IArgument, IArgument]):
         ...
     ...
@@ -632,10 +630,8 @@ Individual = typing.Union[AnonymousIndividual, NamedIndividual]
 PropertyExpression = typing.Union[InverseObjectProperty, ObjectProperty, DataProperty, AnnotationProperty]
 AnnotationSubject = typing.Union[IRI, AnonymousIndividual]
 AnnotationValue = typing.Union[SimpleLiteral, LanguageLiteral, DatatypeLiteral, IRI, AnonymousIndividual]
-Component = typing.Union[
-    OntologyID, DocIRI, OntologyAnnotation, Import, DeclareClass, DeclareObjectProperty, DeclareAnnotationProperty, DeclareDataProperty, DeclareNamedIndividual, DeclareDatatype, SubClassOf, EquivalentClasses, DisjointClasses, DisjointUnion, SubObjectPropertyOf, EquivalentObjectProperties, DisjointObjectProperties, InverseObjectProperties, ObjectPropertyDomain, ObjectPropertyRange, FunctionalObjectProperty, InverseFunctionalObjectProperty, ReflexiveObjectProperty, IrreflexiveObjectProperty, SymmetricObjectProperty, AsymmetricObjectProperty, TransitiveObjectProperty, SubDataPropertyOf, EquivalentDataProperties, DisjointDataProperties, DataPropertyDomain, DataPropertyRange, FunctionalDataProperty, DatatypeDefinition, HasKey, SameIndividual, DifferentIndividuals, ClassAssertion, ObjectPropertyAssertion, NegativeObjectPropertyAssertion, DataPropertyAssertion, NegativeDataPropertyAssertion, AnnotationAssertion, SubAnnotationPropertyOf, AnnotationPropertyDomain, AnnotationPropertyRange, Rule]
-Atom = typing.Union[
-    BuiltInAtom, ClassAtom, DataPropertyAtom, DataRangeAtom, DifferentIndividualsAtom, ObjectPropertyAtom, SameIndividualAtom]
+Component = typing.Union[OntologyID, DocIRI, OntologyAnnotation, Import, DeclareClass, DeclareObjectProperty, DeclareAnnotationProperty, DeclareDataProperty, DeclareNamedIndividual, DeclareDatatype, SubClassOf, EquivalentClasses, DisjointClasses, DisjointUnion, SubObjectPropertyOf, EquivalentObjectProperties, DisjointObjectProperties, InverseObjectProperties, ObjectPropertyDomain, ObjectPropertyRange, FunctionalObjectProperty, InverseFunctionalObjectProperty, ReflexiveObjectProperty, IrreflexiveObjectProperty, SymmetricObjectProperty, AsymmetricObjectProperty, TransitiveObjectProperty, SubDataPropertyOf, EquivalentDataProperties, DisjointDataProperties, DataPropertyDomain, DataPropertyRange, FunctionalDataProperty, DatatypeDefinition, HasKey, SameIndividual, DifferentIndividuals, ClassAssertion, ObjectPropertyAssertion, NegativeObjectPropertyAssertion, DataPropertyAssertion, NegativeDataPropertyAssertion, AnnotationAssertion, SubAnnotationPropertyOf, AnnotationPropertyDomain, AnnotationPropertyRange, Rule]
+Atom = typing.Union[BuiltInAtom, ClassAtom, DataPropertyAtom, DataRangeAtom, DifferentIndividualsAtom, ObjectPropertyAtom, SameIndividualAtom]
 IArgument = typing.Union[AnonymousIndividual, NamedIndividual, Variable]
 DArgument = typing.Union[SimpleLiteral, LanguageLiteral, DatatypeLiteral, Variable]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,176 +1,150 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+//use failure::Error;
+use std::sync::Arc;
+
+use curie::PrefixMapping;
+use horned_bin::path_type;
+use horned_owl::error::HornedError;
+use horned_owl::io::{ParserConfiguration, RDFParserConfiguration, ResourceType};
+use horned_owl::model::*;
+use horned_owl::ontology::iri_mapped::IRIMappedOntology;
+use horned_owl::ontology::set::SetOntology;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyString;
 use pyo3::wrap_pyfunction;
-use std::fs::File;
-use std::io::BufReader;
+
+use crate::ontology::{get_ancestors, get_descendants, PyIndexedOntology};
 
 #[macro_use]
 mod doc;
 mod model;
 mod ontology;
 
-use crate::ontology::{PyIndexedOntology, get_descendants, get_ancestors};
-
-use horned_owl::model::*;
-use horned_owl::ontology::iri_mapped::IRIMappedOntology;
-use horned_owl::io::rdf::reader::IncompleteParse;
-use horned_owl::io::{ParserConfiguration, RDFParserConfiguration};
-use horned_owl::error::HornedError;
-use horned_owl::io::rdf::reader::RDFOntology;
-use horned_owl::ontology::set::SetOntology;
-
-use curie::PrefixMapping;
 
 
-use std::path::Path;
-//use failure::Error;
-use std::sync::Arc;
+#[macro_export]
+macro_rules! to_py_err {
+    ($message:literal) => {
+        | error | PyValueError::new_err(format!("{}: {:?}", $message, error))
+    };
+}
 
 
-fn open_ontology_owx(
-    ontology: &str,
+fn parse_serialization(serialization: Option<&str>) -> Option<ResourceType> {
+    match serialization.map(|s| s.to_lowercase()).as_deref() {
+        Some("owx") => Some(ResourceType::OWX),
+        Some("ofn") => Some(ResourceType::OFN),
+        Some("rdf") => Some(ResourceType::RDF),
+        _ => None
+    }
+}
+
+fn guess_serialization(path: &String, serialization: Option<&str>) -> PyResult<ResourceType> {
+    parse_serialization(serialization).map(Ok).unwrap_or(
+        match serialization.map(|s| s.to_lowercase()).as_deref() {
+            Some(f) => Err(PyValueError::new_err(format!("Unsupported serialization '{}'", f))),
+            None => Ok(path_type(path.as_ref()).unwrap_or(ResourceType::OWX))
+        })
+}
+
+fn open_ontology_owx<R: BufRead>(
+    content: &mut R,
     b: &Build<Arc<str>>,
 ) -> Result<(SetOntology<ArcStr>, PrefixMapping), HornedError> {
-    let r = if Path::new(&ontology).exists() {
-        let file = File::open(ontology).ok().unwrap();
-        let mut f = BufReader::new(file);
-        horned_owl::io::owx::reader::read_with_build(&mut f, &b)
-    } else {
-        //just try to parse the string
-        let str_val = ontology.as_bytes();
-        let mut f = BufReader::new(str_val);
-        horned_owl::io::owx::reader::read_with_build(&mut f, &b)
-    };
-    r
+    horned_owl::io::owx::reader::read_with_build(content, &b)
 }
 
-fn open_ontology_ofn(
-    ontology: &str,
+fn open_ontology_ofn<R: BufRead>(
+    content: &mut R,
     b: &Build<Arc<str>>,
 ) -> Result<(SetOntology<ArcStr>, PrefixMapping), HornedError> {
-    let r = if Path::new(&ontology).exists() {
-        let file = File::open(ontology).ok().unwrap();
-        let mut f = BufReader::new(file);
-        horned_owl::io::ofn::reader::read_with_build(&mut f, &b)
-    } else {
-        //just try to parse the string
-        let str_val = ontology.as_bytes();
-        let mut f = BufReader::new(str_val);
-        horned_owl::io::ofn::reader::read_with_build(&mut f, &b)
-    };
-    r
+    horned_owl::io::ofn::reader::read_with_build(content, &b)
 }
 
-fn open_ontology_rdf(
-    ontology: &str,
-    b: &Build<Arc<str>>,
-) -> Result<
-    (
-        RDFOntology<ArcStr, Arc<AnnotatedComponent<ArcStr>>>,
-        IncompleteParse<Arc<str>>,
-    ),
-    HornedError,
-> {
-    let r = if Path::new(&ontology).exists() {
-        let file = File::open(ontology).ok().unwrap();
-        let mut f = BufReader::new(file);
-        horned_owl::io::rdf::reader::read_with_build(&mut f, &b, ParserConfiguration::default())
-    } else {
-        //just try to parse the string
-        let str_val = ontology.as_bytes();
-        let mut f = BufReader::new(str_val);
-        horned_owl::io::rdf::reader::read_with_build(
-            &mut f,
-            &b,
-            ParserConfiguration {
-                rdf: RDFParserConfiguration { lax: true },
-                ..Default::default()
-            },
-        )
-    };
-    r
+fn open_ontology_rdf<R: BufRead>(
+    content: &mut R,
+    b: &Build<ArcStr>,
+) -> Result<(SetOntology<ArcStr>, PrefixMapping), HornedError> {
+    horned_owl::io::rdf::reader::read_with_build::<ArcStr, ArcAnnotatedComponent, R>(
+        content,
+        &b,
+        ParserConfiguration {
+            rdf: RDFParserConfiguration { lax: true },
+            ..Default::default()
+        },
+    ).map(|(o, _)| (SetOntology::from(o), Default::default()))
 }
 
+/// open_ontology_from_file(path: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology
+///
+/// Opens an ontology from a file
+///
+/// If the serialization is not specified it is guessed from the file extension. Defaults to OWL/XML.
+#[pyfunction(signature = (path, serialization = None))]
+fn open_ontology_from_file(path: String, serialization: Option<&str>) -> PyResult<PyIndexedOntology> {
+    let serialization = guess_serialization(&path, serialization)?;
+
+    let file = File::open(path)?;
+    let mut f = BufReader::new(file);
+
+    let b = Build::new_arc();
+
+    let (onto, mapping) = match serialization {
+        ResourceType::OFN => open_ontology_ofn(&mut f, &b),
+        ResourceType::OWX => open_ontology_owx(&mut f, &b),
+        ResourceType::RDF => open_ontology_rdf(&mut f, &b)
+    }.map_err(to_py_err!("Failed to open ontology"))?;
+
+    let iro = IRIMappedOntology::from(onto);
+    let mut lo = PyIndexedOntology::from(iro);
+    lo.mapping = mapping; //Needed when saving
+    Ok(lo)
+}
+
+/// open_ontology_from_string(ontology: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology
+///
+/// Opens an ontology from plain text.
+///
+/// If no serialization is specified, all parsers are tried until one succeeds
+#[pyfunction(signature = (ontology, serialization = None))]
+fn open_ontology_from_string(ontology: String, serialization: Option<&str>) -> PyResult<PyIndexedOntology> {
+    let serialization = parse_serialization(serialization);
+    let mut f = BufReader::new(ontology.as_bytes());
+
+    let b = Build::new_arc();
+
+    let (onto, mapping) = match serialization {
+        Some(ResourceType::OFN) => open_ontology_ofn(&mut f, &b),
+        Some(ResourceType::OWX) => open_ontology_owx(&mut f, &b),
+        Some(ResourceType::RDF) => open_ontology_rdf(&mut f, &b),
+        None => open_ontology_rdf(&mut f, &b)
+            .or_else(|_| open_ontology_ofn(&mut f, &b))
+            .or_else(|_| open_ontology_owx(&mut f, &b))
+    }.map_err(to_py_err!("Failed to open ontology"))?;
+
+    let iro = IRIMappedOntology::from(onto);
+    let mut lo = PyIndexedOntology::from(iro);
+    lo.mapping = mapping; //Needed when saving
+    Ok(lo)
+}
 
 /// open_ontology(ontology: str) -> PyIndexedOntology
 ///
 /// Opens an ontology from a path or plain text.
 ///
-/// If `ontology` is a path, the file is loaded. Otherwise, `ontology` is interepreted as an ontology in either owx or owl format.
-/// Note: Only .owl and .owx files are currently supported.
-#[pyfunction]
-fn open_ontology(ontology: &PyString) -> PyResult<PyIndexedOntology> {
-    let ontology: String = ontology.extract().unwrap();
-
-    let b = Build::new_arc();
-
-    let result = if ontology.ends_with("owx") {
-        let r = open_ontology_owx(&ontology, &b);
-        //println!("Got result {:?}",r);
-        match r {
-            Ok((o, m)) => {
-                //println!("Got ontology from owx {:?}",o);
-                //println!("About to build indexes");
-                let iro = IRIMappedOntology::from(o);
-                let mut lo = PyIndexedOntology::from(iro);
-                lo.mapping = m; //Needed when saving
-                Ok(lo)
-            }
-            Err(e) => {
-                Err(PyValueError::new_err(format!("Unable to open ontology: {}", e.to_string())))
-            }
-        }
-    } else if ontology.ends_with("ofn") {
-        let r2 = open_ontology_ofn(&ontology, &b);
-        if r2.is_ok() {
-            let (o, _) = r2.ok().unwrap();
-            //println!("Got ontology from rdf {:?}",o);
-            let so = SetOntology::from(o);
-            let iro = IRIMappedOntology::from(so);
-            let lo = PyIndexedOntology::from(iro);
-            Ok(lo)
-        } else {
-            Err(PyValueError::new_err("Unable to open ontology"))
-        }
-    } else if ontology.ends_with("owl") {
-        let r2 = open_ontology_rdf(&ontology, &b);
-        if r2.is_ok() {
-            let (o, _) = r2.ok().unwrap();
-            //println!("Got ontology from rdf {:?}",o);
-            let so = SetOntology::from(o);
-            let iro = IRIMappedOntology::from(so);
-            let lo = PyIndexedOntology::from(iro);
-            Ok(lo)
-        } else {
-            Err(PyValueError::new_err("Unable to open ontology"))
-        }
+/// If `ontology` is a path, the file is loaded. Otherwise, `ontology` is interpreted as an ontology
+/// in plain text.
+/// If no serialization is specified the serialization is guessed by the file extension or all parsers are tried
+/// until one succeeds.
+#[pyfunction(signature = (ontology, serialization = None))]
+fn open_ontology(ontology: String, serialization: Option<&str>) -> PyResult<PyIndexedOntology> {
+    if Path::exists(ontology.as_ref()) {
+        open_ontology_from_file(ontology, serialization)
     } else {
-        // No recognised suffix, maybe it is a string value, just try to parse
-        let r = open_ontology_owx(&ontology, &b);
-        if r.is_ok() {
-            let (o, m) = r.ok().unwrap();
-            //println!("Got ontology from owx {:?}",o);
-            //println!("About to build indexes");
-            let iro = IRIMappedOntology::from(o);
-            let mut lo = PyIndexedOntology::from(iro);
-            lo.mapping = m; //Needed when saving
-            Ok(lo)
-        } else {
-            let r2 = open_ontology_rdf(&ontology, &b);
-            if r2.is_ok() {
-                let (o, _) = r2.ok().unwrap();
-                //println!("Got ontology from rdf {:?}",o);
-                let so = SetOntology::from(o);
-                let iro = IRIMappedOntology::from(so);
-                let lo = PyIndexedOntology::from(iro);
-                Ok(lo)
-            } else {
-                Err(PyValueError::new_err("Unable to open ontology"))
-            }
-        }
-    };
-    result
+        open_ontology_from_string(ontology, serialization)
+    }
 }
 
 #[pymodule]
@@ -178,6 +152,8 @@ fn pyhornedowl(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyIndexedOntology>()?;
 
     m.add_function(wrap_pyfunction!(open_ontology, m)?)?;
+    m.add_function(wrap_pyfunction!(open_ontology_from_file, m)?)?;
+    m.add_function(wrap_pyfunction!(open_ontology_from_string, m)?)?;
     m.add_function(wrap_pyfunction!(get_descendants, m)?)?;
     m.add_function(wrap_pyfunction!(get_ancestors, m)?)?;
 


### PR DESCRIPTION
Closes #18 

- Added the functions `open_ontology_from_file` and `open_ontology_from_string`
- Added `serialization` parameter to all load and save functions to specify the output format
- Added automatic guesses of the output/input format based on file extension

The signature of the changed functions is now as follows:
```py
def open_ontology(ontology: str) -> PyIndexedOntology:
    """
    Opens an ontology from a path or plain text.
    
    If `ontology` is a path, the file is loaded. Otherwise, `ontology` is interpreted as an ontology
    in plain text.
    If no serialization is specified the serialization is guessed by the file extension or all parsers are tried
    until one succeeds.
    """
     ...


def open_ontology_from_file(path: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology:
    """
    Opens an ontology from a file
    
    If the serialization is not specified it is guessed from the file extension. Defaults to OWL/XML.
    """
     ...


def open_ontology_from_string(ontology: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> PyIndexedOntology:
    """
    Opens an ontology from plain text.
    
    If no serialization is specified, all parsers are tried until one succeeds
    """
     ...


class PyIndexedOntology
    def save_to_file(self, file_name: str, serialization: Optional[typing.Literal['owl','ofn', 'owx']]=None) -> None:
        """
        Saves the ontology to disk. If no serialization is given it is guessed by the file extension.
        Defaults to OWL/XML
        """
         ...
     ...

```